### PR TITLE
Tag configure_users.yml with 'rundeck'

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,6 +24,7 @@
 
 # user management
 - include_tasks: configure_users.yml
+  tags: rundeck
 
 # ssh key generation
 - include_tasks: configure_ssh.yml


### PR DESCRIPTION
The instructions for adding an admin user to rundeck are not working unless full rundeck redploy is run.

[The instructions](https://github.com/taptapsend/ansible/blob/master/TAPTAP-RUNDECK.md) say to run:
`ansible-playbook -i taptap-YOUR_TIER_NAME.ini -t rundeck taptap.yml`

However, the rundeck tag doesn't cause the `Users | update basic security to have users` task in this library to be run because it's nested in a separately included file.

My workaround is to add the `rundeck` tag to the `include_tasks` command so that the sub-tasks are available to be run.